### PR TITLE
Fix RootContainer Getter in Items

### DIFF
--- a/Razor/Core/Item.cs
+++ b/Razor/Core/Item.cs
@@ -382,10 +382,14 @@ namespace Assistant
 			{
 				int die = 100;
 				object cont = this.Container;
+				object _rootContainer = cont;
 				while (cont != null && cont is Item && die-- > 0)
+				{
 					cont = ((Item)cont).Container;
+					if (cont != null) _rootContainer = cont;
+				}
 
-				return cont;
+				return _rootContainer;
 			}
 		}
 


### PR DESCRIPTION
Checking the root container of a Bag inside a Chest I see the root container = 0x0000000

Fixed the getter in order to store the correct RootContainer value

Before:
![unknown](https://user-images.githubusercontent.com/57775603/119741522-2e807e00-be86-11eb-8444-d793e4d04dfb.png)

After:
![unknown](https://user-images.githubusercontent.com/57775603/119741594-51ab2d80-be86-11eb-9b89-bc82837ce25e.png)
