### PR TITLE
Added API Misc.FilterSeason - Enable or disable the Seasons filter fo…

### DIFF
--- a/Razor/Core/Player.cs
+++ b/Razor/Core/Player.cs
@@ -217,6 +217,7 @@ namespace Assistant
 		private byte m_GlobalLight;
 		private ushort m_Features;
 		private byte m_Season;
+		private byte m_ForcedSeason;
 		private int[] m_MapPatches = new int[10];
 
 		private bool m_SkillsSent;
@@ -983,6 +984,7 @@ namespace Assistant
 		internal sbyte LocalLightLevel { get { return m_LocalLight; } set { m_LocalLight = value; } }
 		internal byte GlobalLightLevel { get { return m_GlobalLight; } set { m_GlobalLight = value; } }
 		internal byte Season { get { return m_Season; } set { m_Season = value; } }
+		internal byte ForcedSeason { get { return m_ForcedSeason; } set { m_ForcedSeason = value; } }
 		internal ushort Features { get { return m_Features; } set { m_Features = value; } }
 		internal int[] MapPatches { get { return m_MapPatches; } set { m_MapPatches = value; } }
 

--- a/Razor/Filters/Season.cs
+++ b/Razor/Filters/Season.cs
@@ -44,7 +44,7 @@ namespace Assistant.Filters
             {
                 if (World.Player != null)
                 {
-                    Client.Instance.ForceSendToClient(new SeasonChange(0, true));
+                    Client.Instance.ForceSendToClient(new SeasonChange(World.Player.ForcedSeason, true));
                 }
             }
         }
@@ -55,7 +55,7 @@ namespace Assistant.Filters
             if (Client.Instance.AllowBit(FeatureBit.WeatherFilter))
             {
                 args.Block = true;
-                Client.Instance.ForceSendToClient(new SeasonChange(0, true));
+                Client.Instance.ForceSendToClient(new SeasonChange(World.Player.ForcedSeason, true));
             }
         }
     }

--- a/Razor/RazorEnhanced/Misc.cs
+++ b/Razor/RazorEnhanced/Misc.cs
@@ -721,6 +721,37 @@ namespace RazorEnhanced
         {
             return HotKeyEvent.LastEvent;
         }
+
+
+        /// <summary>
+        /// Enable or disable the Seasons filter forcing a specific season
+        /// 0: Spring, 1: Summer, 2: Fall, 3: Winter, 4: Desolation
+        /// Season filter state will be saved on logout but not the season flag that will be recovered to 0: Spring
+        /// </summary>
+        /// <param name="enable">Enable or disable the Seasons filter</param>
+        /// <param name="seasonFlag"> Season flag </param>
+        public static void FilterSeason(Boolean enable, byte seasonFlag)
+        {
+            System.Collections.ArrayList filters = Assistant.Filters.Filter.List;
+            System.Windows.Forms.CheckState checkState;
+
+            checkState = (enable == true) ? System.Windows.Forms.CheckState.Checked : System.Windows.Forms.CheckState.Unchecked;
+
+            int cnt = 0;
+            foreach (var filter in filters)
+            {
+                if (filter is Assistant.Filters.SeasonFilter seasons)
+                {
+                    World.Player.ForcedSeason = seasonFlag;
+                    // Setting the Checked box on the Seasons Filter enabling or disabling the Filter
+                    System.Windows.Forms.CheckedListBox checkbox = Engine.MainWindow.Controls["tabs"].Controls["generalTab"].Controls["groupBox1"].Controls["filters"] as System.Windows.Forms.CheckedListBox;
+                    Client.Instance.ForceSendToClient(new SeasonChange(World.Player.ForcedSeason, true));
+                    checkbox.SetItemCheckState(cnt, checkState);
+                    break;
+                }
+                cnt++;
+            }
+        }
     }
 
 }


### PR DESCRIPTION
Added API Misc.FilterSeason

Enable or disable the Seasons filter forcing a specific season
0: Spring, 1: Summer, 2: Fall, 3: Winter, 4: Desolation
Season filter state will be saved on logout but not the season flag that will be recovered to 0: Spring
