### PR TITLE
Fix for "Collection was modified ... " 

### DIFF
--- a/Razor/Core/ObjectPropertyList.cs
+++ b/Razor/Core/ObjectPropertyList.cs
@@ -39,7 +39,7 @@ namespace Assistant
 		private readonly List<int> m_StringNums = new List<int>();
 
 		private int m_Hash = 0;
-		private readonly List<OPLEntry> m_Content = new List<OPLEntry>();
+		private List<OPLEntry> m_Content = new List<OPLEntry>();
 		internal List<OPLEntry> Content { get { return m_Content; } }
 
 		private readonly UOEntity m_Owner = null;
@@ -53,9 +53,10 @@ namespace Assistant
 
 		internal void Read(PacketReader p)
 		{
-			m_Content.Clear();
+            var property_list = new List<OPLEntry>();
 
-			p.Seek(5, System.IO.SeekOrigin.Begin); // seek to packet data
+
+            p.Seek(5, System.IO.SeekOrigin.Begin); // seek to packet data
 
 			p.ReadUInt32(); // serial
 			p.ReadByte(); // 0
@@ -78,12 +79,14 @@ namespace Assistant
 				if (bytes > 0)
 					args = p.ReadUnicodeStringBE(bytes >> 1);
 
-				if (m_Content.Any(e => e.Number == num))
+				if (property_list.Any(e => e.Number == num))
 					continue;
 				else
-					m_Content.Add(new OPLEntry(num, args));
+                    property_list.Add(new OPLEntry(num, args));
 			}
-		}
+
+            m_Content = property_list;
+        }
 
 		private static readonly int[] m_DefaultStringNums = new int[]
 		{


### PR DESCRIPTION
potential fix for "Collection was modified; enumeration operation may not execute" on Properties
Made the property list an immutable object ( "new" instead of ".Clear()" )


Given that the bug is hard to reproduce, it would require extensive testing to verify the solidity of this bugfix

