### PR TITLE
Add *.png=binary to .gitattributes.

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -9,3 +9,4 @@
 *.datasource text eol=crlf
 *.dll binary
 *.ico binary
+*.png binary


### PR DESCRIPTION
After text=auto was added, png files started being treated as text, causing some very incorrect behavior depending on git config/platform.