### PR TITLE
Add Misc.WaitForCommand(cmd).

### DIFF
--- a/Razor/Core/Commands.cs
+++ b/Razor/Core/Commands.cs
@@ -302,7 +302,7 @@ namespace Assistant
             }
         }
 
-        internal static void Register(string cmd, CommandCallback callback)
+        public static void Register(string cmd, CommandCallback callback)
         {
             if (!m_List.ContainsKey(cmd))
                 m_List.Add(cmd, callback);

--- a/Razor/RazorEnhanced/Misc.cs
+++ b/Razor/RazorEnhanced/Misc.cs
@@ -304,6 +304,20 @@ namespace RazorEnhanced
             System.Threading.Thread.Sleep(millisec);
         }
 
+
+        public static string[] WaitForCommand(string prefix)
+        {
+            Semaphore sem = new Semaphore(0, 1);
+            string[] param = null;
+            Command.Register(prefix, delegate (string[] cmd) {
+                param = cmd;
+                sem.Release();
+            });
+            sem.WaitOne();
+            Command.RemoveCommand(prefix);
+            return param;
+        }
+
         /// <summary>
         /// Trigger a client ReSync.
         /// </summary>


### PR DESCRIPTION
I initially implemented a method of passing arguments to scripts through playscript (seen in https://github.com/wtfuzzy/RazorEnhanced/commit/83a364fb0cae5d73e6d7ed17b78c2d084d2be102). However, that solution A) as-implemented, was Python-specific, B) struck me as somewhat at odds with the general "feel" of RE scripting, and C) didn't actually go as far as I wanted.

This change instead adds a Misc.WaitForCommand method. This is more general (scripts can easily "create a command" and do whatever they want with its parameters), seems to fit in better, and is simpler, touching much less existing code.


I'm personally much happier with this approach. There are two important caveats to this change, though.

1. Command.Register had to be made public.
2. There's no kind of queue - once WaitForCommand returns, the command no longer exists. If the user tries to send the command again before the script gets back around to waiting for it, nothing happens, and the command goes on through as speech. I don't actually see this as much of a problem for sane script usage myself.
