### PR TITLE
FindAllByID(int,...) does not need to duplicate FindAllByID(list,...)

### DIFF
--- a/Razor/RazorEnhanced/Item.cs
+++ b/Razor/RazorEnhanced/Item.cs
@@ -1527,61 +1527,9 @@ namespace RazorEnhanced
 
         public static Item FindByID(int itemid, int color, int container, int range, bool considerIgnoreList = true)
         {
-            if (container != -1)  // search in specific container
-            {
-                // range should be # of packs deep to search .. but not implemented
-                Item cont = FindBySerial(container);
-                if (cont == null) // not valid serial or container not found
-                {
-                    Scripts.SendMessageScriptError("Script Error: FindByID: Container serial not found");
-                    return null;
-                }
-                foreach (Item i in cont.Contains)
-                {
-                    if (considerIgnoreList && Misc.CheckIgnoreObject(i.Serial))
-                        continue;
-
-                    if (i.ItemID == itemid) // check item id
-                    {
-                        if (color != -1) // color -1 ALL
-                        {
-                            if (i.Hue == color)
-                                return i;
-                        }
-                        else
-                        {
-                            return i;
-                        }
-                    }
-                    else if (i.IsContainer && range != 0)
-                    {
-                        Item recursItem = FindByID(itemid, color, i.Serial, range - 1, considerIgnoreList); // recall for sub container
-                        if (recursItem != null)
-                            return recursItem;
-                    }
-                }
-                return null; // Return null if no item found
-            }
-            else  // Search in world
-            {
-                Items.Filter itemFilter = new Items.Filter
-                {
-                    Enabled = true
-                };
-                itemFilter.Graphics.Add(itemid);
-                itemFilter.RangeMax = range;
-                itemFilter.CheckIgnoreObject = considerIgnoreList;
-
-                if (color != -1)
-                    itemFilter.Hues.Add(color);
-
-                List<Item> containeritem = RazorEnhanced.Items.ApplyFilter(itemFilter);
-
-                foreach (Item found in containeritem)  // Return frist one found
-                    return found;
-
-                return null;
-            }
+            var itemids = new List<int>();
+            itemids.Append(itemid);
+            return FindByID(itemids, color, container, range, considerIgnoreList);
         }
 
 

--- a/Razor/RazorEnhanced/Item.cs
+++ b/Razor/RazorEnhanced/Item.cs
@@ -1681,63 +1681,9 @@ namespace RazorEnhanced
         /// <returns>The list of Items matching the criteria.</returns>
         public static IronPython.Runtime.PythonList FindAllByID(int itemid, int color, int container, int range, bool considerIgnoreList = true)
         {
-            if (container != -1)  // search in specific container
-            {
-                // range should be # of packs deep to search .. but not implemented
-                Item cont = FindBySerial(container);
-                if (cont == null) // not valid serial or container not found
-                {
-                    Scripts.SendMessageScriptError("Script Error: FindAllByID: Container serial not found");
-                    return null;
-                }
-                IronPython.Runtime.PythonList returnList = new IronPython.Runtime.PythonList();
-                foreach (Item i in cont.Contains)
-                {
-                    if (considerIgnoreList && Misc.CheckIgnoreObject(i.Serial))
-                        continue;
-
-                    if (i.ItemID == itemid) // check item id
-                    {
-                        if (color != -1) // color -1 ALL
-                        {
-                            if (i.Hue == color)
-                                returnList.Add(i);
-                        }
-                        else
-                        {
-                            returnList.Add(i);
-                        }
-                    }
-                    else if (i.IsContainer && range != 0)
-                    {
-                        var recursItems = FindAllByID(itemid, color, i.Serial, range - 1, considerIgnoreList); // recall for sub container
-                        if (recursItems != null)
-                            returnList += recursItems;
-                    }
-                }
-                return returnList; // Return null if no item found
-            }
-            else  // Search in world
-            {
-                Items.Filter itemFilter = new Items.Filter
-                {
-                    Enabled = true
-                };
-                itemFilter.Graphics.Add(itemid);
-                itemFilter.RangeMax = range;
-                itemFilter.CheckIgnoreObject = considerIgnoreList;
-
-                if (color != -1)
-                    itemFilter.Hues.Add(color);
-
-                var returnList = new IronPython.Runtime.PythonList();
-                foreach(var item in RazorEnhanced.Items.ApplyFilter(itemFilter))
-                {
-                    returnList.Add(item);
-                }
-                
-                return returnList;
-            }
+            var itemids = new IronPython.Runtime.PythonList();
+            itemids.append(itemid);
+            return FindAllByID(itemids, color, container, range, considerIgnoreList);
         }
 
 


### PR DESCRIPTION
FindByID(int,...) and FindAllByID(int,...) are identical to their int[] counterparts except for the sequence handling. With this change, the (int,...) overrides simply call the (int[],...) versions with single-element lists, dropping about 100 lines of redundant code.