### PR TITLE
GetBuffsMapping dict lacked a Veterinary entry.

### DIFF
--- a/Razor/Core/Mobile.cs
+++ b/Razor/Core/Mobile.cs
@@ -42,6 +42,7 @@ namespace Assistant
         private bool m_Warmode;
         private bool m_Paralized;
         private bool m_Flying;
+        private bool m_IsDeadPet;
 
         // Stats & Props
         private bool m_PropsUpdated = false;
@@ -173,6 +174,12 @@ namespace Assistant
         {
             get { return m_Flying; }
             set { m_Flying = value; }
+        }
+
+        internal bool IsDeadPet
+        {
+            get { return m_IsDeadPet; }
+            set { m_IsDeadPet = value; }
         }
 
         internal byte Notoriety

--- a/Razor/Network/Handlers.cs
+++ b/Razor/Network/Handlers.cs
@@ -2796,11 +2796,17 @@ namespace Assistant
                         }
                         break;
                     }
-                case 0x19: //  stat locks
+                case 0x19: //  stat locks, bonded pet status
                     {
-                        if (p.ReadByte() == 0x02)
+                        // 0x19 was originally for stat locks, on a subtype of
+                        // 0x02 (for 2d client, 0x05 for EC). Subtype 0x00 has
+                        // been added for a bonded pet alive/dead flag. There is
+                        // very little public info on the "why" of any of this.
+                        var subtype = p.ReadByte();
+                        var serial = p.ReadUInt32();
+                        var m = World.FindMobile(serial);
+                        if (subtype == 0x02)
                         {
-                            Mobile m = World.FindMobile(p.ReadUInt32());
                             if (World.Player == m && m != null)
                             {
                                 p.ReadByte();// 0?
@@ -2811,6 +2817,10 @@ namespace Assistant
                                 World.Player.DexLock = (LockType)((locks >> 2) & 3);
                                 World.Player.IntLock = (LockType)(locks & 3);
                             }
+                        }
+                        else if (subtype == 0x00)
+                        {
+                            m.IsDeadPet = p.ReadBoolean();
                         }
                         break;
                     }

--- a/Razor/RazorEnhanced/Mobile.cs
+++ b/Razor/RazorEnhanced/Mobile.cs
@@ -77,6 +77,12 @@ namespace RazorEnhanced
         public bool Flying { get { return m_AssistantMobile.Flying; } }
 
         /// <summary>
+        /// The mobile is a dead pet (pet ghost).
+        /// </summary>
+
+        public bool IsDeadPet { get { return m_AssistantMobile.IsDeadPet; } }
+
+        /// <summary>
         /// Check is the Mobile has a human body.
         /// Match any MobileID in the list:
         ///     183, 184, 185, 186, 400, 

--- a/Razor/RazorEnhanced/Player.cs
+++ b/Razor/RazorEnhanced/Player.cs
@@ -664,6 +664,7 @@ namespace RazorEnhanced
                 [BuffIcon.BarakoDraftOfMight] = "Barako Draft Of Might",
                 [BuffIcon.UraliTranceTonic] = "Urali Trance Tonic,",
                 [BuffIcon.SakkhraProphylaxis] = "Sakkhra Prophylaxis",
+                [BuffIcon.Veterinary] = "Veterinary",
             };
 
             return buffs;

--- a/Razor/RazorEnhanced/UOSteamEngine.cs
+++ b/Razor/RazorEnhanced/UOSteamEngine.cs
@@ -445,6 +445,7 @@ namespace RazorEnhanced
 
             UOScript.Interpreter.RegisterExpressionHandler("name", this.Name);
             UOScript.Interpreter.RegisterExpressionHandler("dead", this.IsDead);
+            UOScript.Interpreter.RegisterExpressionHandler("isdeadpet", this.IsDeadPet);
             UOScript.Interpreter.RegisterExpressionHandler("direction", this.Direction); //Dalamar: Fix original UOS direction, in numbers
             UOScript.Interpreter.RegisterExpressionHandler("directionname", this.DirectionName);  //Dalamar: Added RE style directions with names
             UOScript.Interpreter.RegisterExpressionHandler("flying", this.IsFlying);
@@ -1061,6 +1062,23 @@ namespace RazorEnhanced
                 }
             }
 
+            return false;
+        }
+
+        /// <summary>
+        /// isdeadpet (serial)
+        /// </summary>
+        private IComparable IsDeadPet(string expression, UOScript.Argument[] args, bool quiet)
+        {
+            if (args.Length == 1)
+            {
+                uint serial = args[0].AsSerial();
+                Mobile theMobile = Mobiles.FindBySerial((int)serial);
+                if (theMobile != null)
+                {
+                    return theMobile.IsDeadPet;
+                }
+            }
             return false;
         }
 


### PR DESCRIPTION
This prevented the Veterinary bufficon from being tracked correctly when bandaging a pet, causing Player.BuffsExist("Veterinary") to always return false.