### PR TITLE
#15 Feat add targetexists any, harmful, neutral and beneficial on ste…

### DIFF
--- a/Razor/RazorEnhanced/UOSteamEngine.cs
+++ b/Razor/RazorEnhanced/UOSteamEngine.cs
@@ -15,6 +15,7 @@ using System.Windows.Forms;
 using System.Text.RegularExpressions;
 using System.IO;
 using System.Threading;
+using System.Globalization;
 
 namespace RazorEnhanced
 {
@@ -1760,13 +1761,18 @@ namespace RazorEnhanced
         }
 
         /// <summary>
-        ///  targetexists ('timer name')
+        ///  targetexists ('Any' | 'Harmful' | 'Neutral' | 'Beneficial')
         /// </summary>
         private IComparable TargetExists(string expression, UOScript.Argument[] args, bool quiet)
         {
-            if (args.Length == 0) { WrongParameterCount(expression, 1, args.Length); }
-
-            return true;
+            if (args.Length >= 1)
+            {
+                CultureInfo cultureInfo = Thread.CurrentThread.CurrentCulture;
+                TextInfo textInfo = cultureInfo.TextInfo;
+                string targetFlag = textInfo.ToTitleCase(args[0].AsString().ToLower());
+                return RazorEnhanced.Target.HasTarget(targetFlag);
+            }
+            return RazorEnhanced.Target.HasTarget();
         }
 
         /// <summary>


### PR DESCRIPTION
Issue #15

After update from Target.HasTarget('targetFlags'), it was possible to do that issue #15. So UOSteamEngine.cs was updated with new features.
 
![image](https://user-images.githubusercontent.com/1846503/221428385-0e8d54de-e564-4ebb-8b5a-d549e7c5f789.png)

Now, u can use targetexists steam's command as:

```
sysmsg '--------------------------' 106

if targetexists 
    sysmsg 'Target is ANY (harmful, neutral or beneficial)' 55
endif

if targetexists 'Any'
    sysmsg 'Target is ANY (harmful, neutral or beneficial)' 55
endif

if targetexists 'Harmful'
    sysmsg 'Target is harmful' 22
endif 

if targetexists 'Neutral'
    sysmsg 'Target is neutral' 22
endif 

if targetexists 'Beneficial'
    sysmsg 'Target is beneficial' 22
endif 
```

Evidence:

![image](https://user-images.githubusercontent.com/1846503/221428637-c72d5723-e114-4f01-a75f-09d47a4d1495.png)
