### PR TITLE
UpdatedStagger with correct Id from what is sent from GameClient

### DIFF
--- a/Razor/Core/SkillIcon.cs
+++ b/Razor/Core/SkillIcon.cs
@@ -54,7 +54,7 @@ namespace Assistant
         PlayingTheOdds,
         Thrust,
         Pierce,
-        Stagger,
+        Stagger = 0x2D7,
         Toughness,
         Onslaught = 0x2D9,
         FocusedEye,


### PR DESCRIPTION
*Stagger (mace fighting mastery) had incorrect enum, game send 727 (0x2D7) but since it was not defined it follows incremental and thus had value 535

Suggestion for future:
Assign all enums on their actual values, nondefined values enums should only be used when there is never a reverse lookup as is done here in handlers on line 2844

SkillIcon skill = (SkillIcon)skillid;

Reason for this is the following
public enum Example {
left,
right,
up,
down,
}
In this case Up gets value 2 (3'rd index)

public enum Example2 {
left,
right = 5,
up,
down,
}

If by any reason right gets defined to 5,, rnum valuea are now
left = 0
right = 5
up = 6
down = 7

By adding 1 number out of sequence the whole sequence gets moved to increment from specified sequence