### PR TITLE
Added CUO Commands

### DIFF
--- a/Razor/RazorEnhanced/CUO.cs
+++ b/Razor/RazorEnhanced/CUO.cs
@@ -376,6 +376,37 @@ namespace RazorEnhanced
             }
         }
 
+        /// <summary>
+        /// Set a location that CUO will open the next gump or container at
+        /// </summary>
+        public static void NextGumpLocation(int gumpserial, int x, int y)
+        {
+            NextGumpLocation((uint)gumpserial, x, y);
+        }
+
+        /// <summary>
+        /// Set a location that CUO will open the next gump or container at
+        /// </summary>
+        public static void NextGumpLocation(uint gumpserial, int x, int y)
+        {
+            if (!Client.IsOSI)
+            {
+
+                System.Reflection.Assembly assembly = AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(assembly => assembly.GetName().Name == "FNA");
+                if (assembly != null)
+                {
+                    Type Point = assembly.GetType("Microsoft.Xna.Framework.Point");
+                    System.Reflection.ConstructorInfo ctor = Point.GetConstructor(new[] { typeof(int), typeof(int) });
+                    var pos = ctor.Invoke(new object[] { x, y });
+                    var SavePosition = ClassicUOClient.CUOAssembly?.GetType("ClassicUO.Game.Managers.UIManager")?.GetMethod("SavePosition", BindingFlags.Public | BindingFlags.Static);
+                    if (SavePosition != null)
+                    {
+                        SavePosition.Invoke(assembly, new object[] { (uint)gumpserial, pos });
+                    }
+                }
+            }
+        }
+
         public static void CloseGump(uint serial)
         {
             if (!Client.IsOSI)

--- a/Razor/RazorEnhanced/CUO.cs
+++ b/Razor/RazorEnhanced/CUO.cs
@@ -11,6 +11,12 @@ using static RazorEnhanced.HotKey;
 using System.Windows.Forms;
 using System.IO;
 using System.Reflection;
+using Accord.Imaging.Filters;
+using IronPython.Runtime;
+using System.Globalization;
+using System.Web.UI.WebControls;
+using Accord.Collections;
+using Accord.Math;
 
 namespace RazorEnhanced
 {
@@ -68,7 +74,6 @@ namespace RazorEnhanced
                 }
             }
         }
-
 
         /// <summary>
         /// Invokes the GoToMarker function inside the CUO code
@@ -246,8 +251,6 @@ namespace RazorEnhanced
             return result;
         }
 
-
-
         /// <summary>
         /// Set a bool Config property in CUO by name
         /// </summary>
@@ -407,6 +410,283 @@ namespace RazorEnhanced
             }
         }
 
+        /// <summary>
+        /// Invokes the Method to close your status bar gump inside the CUO code
+        /// </summary>
+        public static void CloseStatusGump()
+        {
+            if (!Client.IsOSI)
+            {
+                System.Reflection.Assembly assembly = AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(assembly => assembly.GetName().Name == "FNA");
+                if (assembly != null)
+                {
+                    var StatusGumpBase = ClassicUOClient.CUOAssembly?.GetType("ClassicUO.Game.UI.Gumps.StatusGumpBase");
+                    if (StatusGumpBase != null)
+                    {
+                        var status = StatusGumpBase?.GetMethod("GetStatusGump", BindingFlags.Public | BindingFlags.Static);
+                        if (status != null)
+                        {
+                            var gump = status.Invoke(assembly, new object[] { });
+
+                            if(gump!= null)
+                            {
+                                var Gumps = ClassicUOClient.CUOAssembly?.GetType("ClassicUO.Game.UI.Gumps.Gump");
+                                if (Gumps != null)
+                                {
+                                    MethodInfo Dispose = Gumps.GetMethod("Dispose");
+                                    if (Dispose != null)
+                                    {
+                                        Dispose.Invoke(gump, new object[] { });
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Invokes the Method to open your status bar gump inside the CUO code
+        /// </summary>
+        public static void OpenStatusBar(int x, int y)
+        {
+            if (!Client.IsOSI)
+            {
+                CloseStatusGump();
+                System.Reflection.Assembly assembly = AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(assembly => assembly.GetName().Name == "FNA");
+                if (assembly != null)
+                {
+                    var StatusGumpBase = ClassicUOClient.CUOAssembly?.GetType("ClassicUO.Game.UI.Gumps.StatusGumpBase");
+                    if (StatusGumpBase != null)
+                    {
+                        var status = StatusGumpBase?.GetMethod("AddStatusGump", BindingFlags.Public | BindingFlags.Static);
+                        if (status != null)
+                        {
+                            var parameters = new object[2] { x, y };
+                            var gump = status.Invoke(assembly, parameters);
+                            
+                            var uimanager = ClassicUOClient.CUOAssembly?.GetType("ClassicUO.Game.Managers.UIManager");
+                            if (uimanager != null)
+                            {
+                                var add = uimanager?.GetMethod("Add", BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance);
+                                 if(add != null)
+                                {
+                                    add.Invoke(assembly, new object[] { gump, true });
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Set a location that CUO will open the next gump or container at
+        /// </summary>
+        public static void OpenMobileStatusBar(int mobileserial, int x, int y)
+        {
+            OpenMobileStatusBar((uint)mobileserial, x, y);
+        }
+
+        /// <summary>
+        /// Invokes the Method to open your status bar gump inside the CUO code
+        /// </summary>
+        public static void OpenMobileStatusBar(uint mobileserial, int x, int y)
+        {
+            if (!Client.IsOSI)
+            {
+                System.Reflection.Assembly assembly = AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(assembly => assembly.GetName().Name == "FNA");
+                if (assembly != null)
+                {
+                    var StatusGumpBase = ClassicUOClient.CUOAssembly?.GetType("ClassicUO.Game.UI.Gumps.HealthBarGump");
+                    if (StatusGumpBase != null)
+                    {
+                        Type[] types = new Type[1];
+                        types[0] = typeof(uint);
+
+                        var status = StatusGumpBase?.GetConstructor(types);
+
+                        if (status != null)
+                        {
+                            var parameters = new object[1] { (uint)mobileserial };
+                            var gump = status.Invoke(parameters);
+
+                            var uimanager = ClassicUOClient.CUOAssembly?.GetType("ClassicUO.Game.Managers.UIManager");
+                            if (uimanager != null)
+                            {
+                                var add = uimanager?.GetMethod("Add", BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance);
+                                if (add != null)
+                                {
+                                    add.Invoke(assembly, new object[] { gump, true});
+
+                                    var prop = StatusGumpBase.GetProperty("Location");
+
+                                    Type Point = assembly.GetType("Microsoft.Xna.Framework.Point");
+                                    System.Reflection.ConstructorInfo ctor = Point.GetConstructor(new[] { typeof(int), typeof(int) });
+                                    var pos = ctor.Invoke(new object[] { x, y });
+
+                                    if (prop != null)
+                                    {
+                                        prop.SetValue(gump, pos, null);
+                                    }
+
+                                  
+
+
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Set a location that CUO will open the next gump or container at
+        /// </summary>
+        public static void OpenCustomMobileStatusBar(int mobileserial, int x, int y)
+        {
+            OpenCustomMobileStatusBar((uint)mobileserial, x, y);
+        }
+
+        /// <summary>
+        /// Invokes the Method to open your status bar gump inside the CUO code
+        /// </summary>
+        public static void OpenCustomMobileStatusBar(uint mobileserial, int x, int y)
+        {
+            if (!Client.IsOSI)
+            {
+                System.Reflection.Assembly assembly = AppDomain.CurrentDomain.GetAssemblies().SingleOrDefault(assembly => assembly.GetName().Name == "FNA");
+                if (assembly != null)
+                {
+                    var StatusGumpBase = ClassicUOClient.CUOAssembly?.GetType("ClassicUO.Game.UI.Gumps.HealthBarGumpCustom");
+                    if (StatusGumpBase != null)
+                    {
+                        Type[] types = new Type[1];
+                        types[0] = typeof(uint);
+
+                        var status = StatusGumpBase?.GetConstructor(types);
+
+                        if (status != null)
+                        {
+                            var parameters = new object[1] { (uint)mobileserial };
+                            var gump = status.Invoke(parameters);
+
+                            var uimanager = ClassicUOClient.CUOAssembly?.GetType("ClassicUO.Game.Managers.UIManager");
+                            if (uimanager != null)
+                            {
+                                var add = uimanager?.GetMethod("Add", BindingFlags.Public | BindingFlags.Static | BindingFlags.Instance);
+                                if (add != null)
+                                {
+                                    add.Invoke(assembly, new object[] { gump, true });
+
+                                    var prop = StatusGumpBase.GetProperty("Location");
+
+                                    Type Point = assembly.GetType("Microsoft.Xna.Framework.Point");
+                                    System.Reflection.ConstructorInfo ctor = Point.GetConstructor(new[] { typeof(int), typeof(int) });
+                                    var pos = ctor.Invoke(new object[] { x, y });
+
+                                    if (prop != null)
+                                    {
+                                        prop.SetValue(gump, pos, null);
+                                    }
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+
+        /// <summary>
+        /// Closes a Mobile Status Gump of an Entity
+        /// </summary>
+        public static void CloseMobileStatusGump(int mobileserial)
+        {
+            CloseMobileStatusGump((uint)mobileserial);
+        }
+
+        /// <summary>
+        /// Closes a Mobile Status Gump of an Entity
+        /// </summary>
+        public static void CloseMobileStatusGump(uint mobileserial)
+        {
+            if (!Client.IsOSI)
+            {
+                var getAllGumps = ClassicUOClient.CUOAssembly?.GetType("ClassicUO.Game.Managers.UIManager")?.GetProperty("Gumps", BindingFlags.Public | BindingFlags.Static);
+                if (getAllGumps != null)
+                {
+                    var listOfGumps = getAllGumps.GetValue(null);
+                    if (listOfGumps != null)
+                    {
+                        IEnumerable<Object> temp = listOfGumps as IEnumerable<Object>;
+                        foreach (var gump in temp)
+                        {
+                            if (gump != null)
+                            {
+                                var GumpType = ClassicUOClient.CUOAssembly?.GetType("ClassicUO.Game.UI.Gumps.Gump")?.GetProperty("GumpType", BindingFlags.Public | BindingFlags.Instance);
+                                if (GumpType != null)
+                                {
+                                    int GumpTypeEnum = (int)GumpType.GetValue(gump);
+                                    if (GumpTypeEnum == 4)
+                                    {
+                                        var HealthBarGump = ClassicUOClient.CUOAssembly?.GetType("ClassicUO.Game.UI.Gumps.HealthBarGump");
+                                        if (HealthBarGump != null)
+                                        {
+                                            var prop = HealthBarGump.GetProperty("LocalSerial", BindingFlags.Instance | BindingFlags.Public);
+                                            if (prop != null)
+                                            {
+                                                Misc.SendMessage("We Found this Property");
+
+                                                var gumpserial = prop.GetValue(HealthBarGump);
+
+
+                                                Misc.SendMessage("local serial is " + gumpserial);
+
+                                                if ((uint)gumpserial == mobileserial)
+                                                {
+                                                    MethodInfo Dispose = HealthBarGump.GetMethod("Dispose");
+                                                    if (Dispose != null)
+                                                    {
+                                                        Dispose.Invoke(gump, new object[] { });
+                                                    }
+
+                                                }
+                                            }
+
+                                            /*
+                                            foreach (var settingSearch in HealthBarGump.GetProperties())
+                                            {
+                                                Misc.SendMessage("Property is: " + settingSearch);
+                                                
+                                                if (settingSearch.Name == "LocalSerial")
+                                                {
+                                                    Misc.SendMessage("Property is: " + settingSearch);
+
+                                                    var varvar = (UInt32)settingSearch.GetValue(HealthBarGump );
+                                                    //var varvar = settingSearch.GetValue(HealthBarGump);
+
+                                                    Misc.SendMessage("Property Value is: " + varvar);
+                                                }
+                                                
+                                            }
+                                            */
+                                        }
+                                    }
+                                   
+                                }
+                            }
+                        }
+                    }
+                }
+
+            }
+        }
+
+        /// <summary>
+        /// Invokes the Method close a gump
+        /// </summary>
         public static void CloseGump(uint serial)
         {
             if (!Client.IsOSI)
@@ -471,6 +751,7 @@ namespace RazorEnhanced
             return "";
 
         }
+        
         /// <summary>
         /// Play a CUO macro by name
         /// Warning, limited testing !! 
@@ -578,6 +859,7 @@ namespace RazorEnhanced
             }
             return;
         }
+
     }
 }
 

--- a/Razor/RazorEnhanced/Gumps.cs
+++ b/Razor/RazorEnhanced/Gumps.cs
@@ -276,6 +276,18 @@ namespace RazorEnhanced
         }
 
         /// <summary>
+        /// Add tooltip to the previously added control
+        /// </summary>
+        /// <param name="gd"> GumpData structure</param>
+        /// <param name="cliloc"> cliloc for tooltip</param>
+        /// <param name="text"> string for tooltip</param>
+        public static void AddTooltip(ref GumpData gd, int cliloc, string text)
+        {
+            string textEntry = string.Format("{{ tooltip {0} @{1}@ }}", cliloc, text);
+            gd.gumpDefinition += textEntry;
+        }
+
+        /// <summary>
         /// Add a textured background for the gump. Its a transparent background
         /// </summary>
         /// <param name="gd"> GumpData structure</param>


### PR DESCRIPTION
added a few commands for use with CUO.


SetGumpOpenLocation(uint gumpserial, int x, int y)  - sets the location for when the gump with that serial gets opened next.


MoveGump(uint serial, int x, int y) - moves a gump if opened to a different location.

CloseMyStatusBar() - Closes the player's large status window.

OpenMyStatusBar(int x, int y) - Opens the player's large status window to a specified location.

OpenMobileHealthBar(int mobileserial, int x, int y, bool custom) - Opens the health bar of a mobile when the serial is set into the specified location. bool can switch between the custom bar and the normal health bar.

CloseMobileHealthBar(int mobileserial) - closes the health bar of a mobile when the serial is set.