### PR TITLE
Fixed CSharpEngine directive //#assembly for nested C# scripts

### DIFF
--- a/Razor/RazorEnhanced/CSharpEngine.cs
+++ b/Razor/RazorEnhanced/CSharpEngine.cs
@@ -203,7 +203,7 @@ namespace RazorEnhanced
 
                 if (foundDirectives.Count <= 0)
                 {
-                    return;
+                    continue;
                 }
 
                 string basepath = Path.GetDirectoryName(filename); // BasePath of the imported file


### PR DESCRIPTION
Fix: CSharpEngine looks for //#assembly<MyDLL.dll> inside the C# script and generates a list of used assemblies. If the script contains a directive //#import<other_cpp_file.cs> and this imported file uses an assembly this should be considered. A return instead of a continue broke this functionality.