### PR TITLE
RE will kill VBCSCompiler before closing

### DIFF
--- a/Razor/Client/Client.cs
+++ b/Razor/Client/Client.cs
@@ -541,6 +541,8 @@ namespace Assistant
 
             ScriptRecorderService.Instance.RemoveAll();
             //RazorEnhanced.UI.EnhancedScriptEditor.End();
+
+            RazorEnhanced.CSharpEngine.Stop();
         }
 
 

--- a/Razor/RazorEnhanced/CSharpEngine.cs
+++ b/Razor/RazorEnhanced/CSharpEngine.cs
@@ -10,6 +10,9 @@ using System.Text.RegularExpressions;
 
 namespace RazorEnhanced
 {
+    /// <summary>
+    /// This class is used to compile and execute C# scripts.
+    /// </summary>
     public class CSharpEngine
     {
         private static CSharpEngine m_instance = null;
@@ -420,5 +423,54 @@ namespace RazorEnhanced
             run.Invoke(scriptInstance, null);
         }
 
+        /// <summary>
+        /// Kills the VBCSCompiler process if no other RazorEnhanced or ClassicUO process is running
+        /// </summary>
+        public static void Stop()
+        {
+            System.Diagnostics.Process[] pRazor = System.Diagnostics.Process.GetProcessesByName("RazorEnhanced");
+            System.Diagnostics.Process[] pCUO = System.Diagnostics.Process.GetProcessesByName("ClassicUO");
+
+            // Get application PID
+            int pid = System.Diagnostics.Process.GetCurrentProcess().Id;
+
+
+            bool bOtherRazorRunning = false;
+            bool bOtherCUORunning = false;
+
+            foreach (System.Diagnostics.Process process in pRazor)
+            {
+                if (process.Id != pid)
+                {
+                    bOtherRazorRunning = true;
+                    break;
+                }
+            }
+
+            foreach (System.Diagnostics.Process process in pCUO)
+            {
+                if (process.Id != pid)
+                {
+                    bOtherCUORunning = true;
+                    break;
+                }
+            }
+
+            // If one process is runnig, no need to kill VBCSCompiler
+            if (bOtherRazorRunning || bOtherCUORunning)
+            {
+                return;
+            }
+
+            // Kill all VBCSCompiler executable
+            if (System.Diagnostics.Process.GetProcessesByName("VBCSCompiler").Length != 0)
+            {
+                System.Diagnostics.Process[] processes = System.Diagnostics.Process.GetProcessesByName("VBCSCompiler");
+                foreach (System.Diagnostics.Process process in processes)
+                {
+                    process.Kill();
+                }
+            }
+        }
     }
 }


### PR DESCRIPTION
When the AutoUpdater starts updating Razor, can happen that it hangs because of the running VBCSCompiler process (It tries to overwrite the running executable during installation of the update). To remedy this problem, Razor will kill the process but only if there are no other instances of RE running. The reason Roslyn keeps VBCSCompiler always running, is for a matter of optimization and compile time reduction.